### PR TITLE
ci: use foundry-toolchain action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,19 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install .
           pip install -r requirements-dev.txt
-          wget -qO- "https://github.com/foundry-rs/foundry/releases/download/nightly-25d3ce7ca1eed4a9f1776103185e4221e8fa0a11/foundry_nightly_linux_amd64.tar.gz" | tar xvfz - anvil
       - name: Try anvil
-        run: ./anvil --version
+        run: anvil --version
       - name: Run tests
-        run: PATH=${PATH}:. RR_RUN_LOCAL_NODE=1 pytest -v --cov
+        run: RR_RUN_LOCAL_NODE=1 pytest -v --cov
       - name: Coverage report
         run: coverage report
       - name:  Anvil log


### PR DESCRIPTION
Fixes the CI as anvil is only available as nightly snapshots and they are pruned if older than a week or so.